### PR TITLE
multiple small fixes in ceilometermiddleware

### DIFF
--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -44,6 +44,8 @@ before "proxy-server" and add the following filter in the file:
     send_queue_size = 1000
     # Logging level control
     log_level = WARNING
+    # to emit event for all http requests (PUT/POST/COPY/GET/HEAD/DELETE)
+    notify_api_count = False
 
     # All keystoneauth1 options can be set to query project name for
     # ignore_projects option, here is just a example:
@@ -179,6 +181,9 @@ class Swift(object):
         self.reseller_prefix = conf.get('reseller_prefix', 'AUTH_')
         if self.reseller_prefix and self.reseller_prefix[-1] != '_':
             self.reseller_prefix += '_'
+
+        self.notify_api_count = strutils.bool_from_string(
+            conf.get('notify_api_count', False))
 
         LOG.setLevel(getattr(logging, conf.get('log_level', 'WARNING')))
 
@@ -382,6 +387,15 @@ class Swift(object):
                 metric=cadf_metric.Metric(
                     name='storage.objects.outgoing.bytes', unit='B')))
 
+        # api calls
+        if self.notify_api_count:
+            request_metric_name = self.get_request_metric_name(method.lower())
+            if request_metric_name:
+                event.add_measurement(cadf_measurement.Measurement(
+                    result=1,
+                    metric=cadf_metric.Metric(
+                        name=request_metric_name, unit='request')))
+
         if self.nonblocking_notify:
             try:
                 Swift.event_queue.put(event, False)
@@ -403,6 +417,18 @@ class Swift(object):
     @staticmethod
     def send_notification(notifier, event):
         notifier.info({}, 'objectstore.http.request', event.as_dict())
+
+    @staticmethod
+    def get_request_metric_name(method):
+        request_metric_names = {
+            'get': 'storage.objects.get.count',
+            'post': 'storage.objects.post.count',
+            'put': 'storage.objects.put.count',
+            'copy': 'storage.objects.copy.count',
+            'delete': 'storage.objects.delete.count',
+            'head': 'storage.objects.head.count'
+        }
+        return request_metric_names.get(method, None)
 
 
 class SendEventThread(threading.Thread):

--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -295,7 +295,8 @@ class Swift(object):
         if ((env.get('HTTP_X_SERVICE_PROJECT_ID') or
                 env.get('HTTP_X_PROJECT_ID') or
                 env.get('HTTP_X_TENANT_ID')) in self.ignore_projects or
-                env.get('swift.source') is not None):
+                (env.get('swift.source') is not None and
+                    env.get('swift.source') != 'S3')):
             return
 
         path = urlparse.quote(env['PATH_INFO'])
@@ -345,9 +346,14 @@ class Swift(object):
                     header.upper())
 
         # build object store details
-        target = cadf_resource.Resource(
-            typeURI='service/storage/object',
-            id=account.partition(self.reseller_prefix)[2] or path)
+        if self.reseller_prefix:
+            target = cadf_resource.Resource(
+                typeURI='service/storage/object',
+                id=account.partition(self.reseller_prefix)[2] or path)
+        else:
+            target = cadf_resource.Resource(
+                typeURI='service/storage/object',
+                id=account)
         target.metadata = resource_metadata
         target.action = method.lower()
 


### PR DESCRIPTION
 #### Description
1. handled exception when reseller_prefix is set to empty string
2. enabled event notification for `swift.source=s3api`

#### Related Issue

#### Types of changes
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
- [x] :bug: Bug fix (non-breaking change which fixes an issue).
- [ ] :rocket: New feature (non-breaking change which adds functionality).
- [ ] :heavy_multiplication_x: Breaking change (fix or feature that would cause existing functionality to change).

#### Checklist
The following checklist should be checked on each new pull requests as well as the subsequent changes in the pull request.
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [x] I have rebased the code with master(must).

#### What is the current behavior? (You can also link to an open issue here)
1. when we set the reseller_prefix is set to empty string swift-proxy ceilometermiddleware runs into the following exception
```
STDERR: ERROR:ceilometermiddleware.swift:An exception occurred processing the API call: empty separator #012Traceback (most recent call last):#012 File "/usr/lib/python2.7/site-packages/ceilometermiddleware/swift.py", line 98, in wrapper#012 return fn(*args, **kwargs)#012 File "/usr/lib/python2.7/site-packages/ceilometermiddleware/swift.py", line 342, in emit_event#012 id=account.partition(self.reseller_prefix)[2] or path)#012ValueError: empty separator (txn: txc750116f2a644428b8577-005d239afb)
```
2. ceilometermiddleware was not notifying s3api events 

####  What is the new behavior (if this is a feature change)?
1. handled exception when reseller_prefix is empty
2. notify events when `swift.source=S3`
