### PR TITLE
applied monkey_patch for ceilometermiddleware

### DIFF
--- a/ceilometermiddleware/__init__.py
+++ b/ceilometermiddleware/__init__.py
@@ -14,9 +14,10 @@
 
 import pbr.version
 import eventlet
-eventlet.sleep()
-eventlet.monkey_patch()
 
 
 __version__ = pbr.version.VersionInfo(
     'ceilometermiddleware').version_string()
+
+eventlet.sleep()
+eventlet.monkey_patch()

--- a/ceilometermiddleware/__init__.py
+++ b/ceilometermiddleware/__init__.py
@@ -13,6 +13,9 @@
 # under the License.
 
 import pbr.version
+import eventlet
+eventlet.sleep()
+eventlet.monkey_patch()
 
 
 __version__ = pbr.version.VersionInfo(

--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -58,11 +58,6 @@ before "proxy-server" and add the following filter in the file:
     password = a_big_secret
     interface = public
 """
-
-import eventlet
-eventlet.sleep()
-eventlet.monkey_patch()
-
 import datetime
 import functools
 import logging

--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -58,6 +58,11 @@ before "proxy-server" and add the following filter in the file:
     password = a_big_secret
     interface = public
 """
+
+import eventlet
+eventlet.sleep()
+eventlet.monkey_patch()
+
 import datetime
 import functools
 import logging


### PR DESCRIPTION
#### Description
In order to use oslo.messaging with greenthreads (eventlet), the application must override all system library calls that can block the thread. Eventlet provides a method to do exactly that: monkey_patch(). This PR does the same

#### Related Issue
Fixes #2  

#### Types of changes
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
- [ ] :bug: Bug fix (non-breaking change which fixes an issue).
- [x] :rocket: New feature (non-breaking change which adds functionality).
- [ ] :heavy_multiplication_x: Breaking change (fix or feature that would cause existing functionality to change).

#### Checklist
The following checklist should be checked on each new pull requests as well as the subsequent changes in the pull request.
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [x] I have rebased the code with master(must).

#### What is the current behavior? (You can also link to an open issue here)
[refer](https://github.com/idrive-online-backup/ceilometermiddleware/issues/2)


####  What is the new behavior (if this is a feature change)?
Refer description

#### How was the fix tested?


#### If this PR introduce a breaking change, what changes might users need to make in their application due to this PR?


#### Screenshots (if appropriate)


#### Other information:
