### PR TITLE
fix static web call metrics are not send to rabbitmw

### DIFF
--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -301,7 +301,7 @@ class Swift(object):
                 env.get('HTTP_X_PROJECT_ID') or
                 env.get('HTTP_X_TENANT_ID')) in self.ignore_projects or
                 (env.get('swift.source') is not None and
-                    env.get('swift.source') != 'S3')):
+                    env.get('swift.source') not in ['SW', 'S3'])):
             return
 
         path = urlparse.quote(env.get('swift.backend_path', env['PATH_INFO']))


### PR DESCRIPTION
Issue:
For static web calls the swift.source is SW and ceilometer middleware skip such request without sending the metrics to rabbitmq
Fix:
Added condition to not skip if source is set to SW